### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,4 @@ gem 'image_processing', '~>1.2'
 gem 'active_hash'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.4.1)
       actionpack (= 6.0.4.1)
       activesupport (= 6.0.4.1)
@@ -327,6 +330,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,14 +11,14 @@ class Item < ApplicationRecord
 
   validates :item_name, presence: true
   validates :item_text, presence: true
-  validates :category_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :sales_status_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :shipping_cost_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :shipping_area_id, numericality: { other_than: 1, message: "can't be blank" }
-  validates :day_to_ship_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :category_id, numericality: { other_than: 1, message: "が選択されていません" }
+  validates :sales_status_id, numericality: { other_than: 1, message: "が選択されていません" }
+  validates :shipping_cost_id, numericality: { other_than: 1, message: "が選択されていません" }
+  validates :shipping_area_id, numericality: { other_than: 1, message: "が選択されていません" }
+  validates :day_to_ship_id, numericality: { other_than: 1, message: "が選択されていません" }
   validates :price, presence: true
-  validates :price, numericality: { only_integer: true, message: 'is invalid. Input half-width characters' }, allow_blank: true
+  validates :price, numericality: { only_integer: true, message: 'は半角数字で入力してください' }, allow_blank: true
   validates :price,
-            numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'Out of setting range' }, allow_blank: true
+            numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }, allow_blank: true
   validates :image, presence: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,11 +11,11 @@ class Item < ApplicationRecord
 
   validates :item_name, presence: true
   validates :item_text, presence: true
-  validates :category_id, numericality: { other_than: 1, message: "が選択されていません" }
-  validates :sales_status_id, numericality: { other_than: 1, message: "が選択されていません" }
-  validates :shipping_cost_id, numericality: { other_than: 1, message: "が選択されていません" }
-  validates :shipping_area_id, numericality: { other_than: 1, message: "が選択されていません" }
-  validates :day_to_ship_id, numericality: { other_than: 1, message: "が選択されていません" }
+  validates :category_id, numericality: { other_than: 1, message: 'が選択されていません' }
+  validates :sales_status_id, numericality: { other_than: 1, message: 'が選択されていません' }
+  validates :shipping_cost_id, numericality: { other_than: 1, message: 'が選択されていません' }
+  validates :shipping_area_id, numericality: { other_than: 1, message: 'が選択されていません' }
+  validates :day_to_ship_id, numericality: { other_than: 1, message: 'が選択されていません' }
   validates :price, presence: true
   validates :price, numericality: { only_integer: true, message: 'は半角数字で入力してください' }, allow_blank: true
   validates :price,

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -13,7 +13,7 @@ class OrderAddress
     validates :item_id
   end
 
-  validates :prefectures_id, numericality: { other_than: 1, message: "が選択されていません" }
+  validates :prefectures_id, numericality: { other_than: 1, message: 'が選択されていません' }
 
   def save
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -3,17 +3,17 @@ class OrderAddress
   attr_accessor :post_code, :prefectures_id, :municipalities, :address, :building_num, :telephone_num, :item_id, :user_id, :token
 
   with_options presence: true do
-    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Enter it as follows (e.g. 123-4567)' }
+    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'を正しく入力してください(例 123-4567)' }
     validates :municipalities
     validates :address
-    validates :telephone_num, format: { with: /\A\d{10}\z|\A\d{11}\z/, message: 'is too short' },
-                              numericality: { only_integer: true, message: 'is invalid. Input only number' }
+    validates :telephone_num, format: { with: /\A\d{10}\z|\A\d{11}\z/, message: 'は10桁か11桁で入力してください' },
+                              numericality: { only_integer: true, message: 'は半角数字のみで入力してください' }
     validates :token
     validates :user_id
     validates :item_id
   end
 
-  validates :prefectures_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefectures_id, numericality: { other_than: 1, message: "が選択されていません" }
 
   def save
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima37246
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: メールアドレス
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        first_name: 名前
+        first_name_kana: 名前(カナ)
+        last_name: 名字
+        last_name_kana: 名字(カナ)
+        date_of_birth: 生年月日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,12 @@ ja:
         shipping_area_id: 配送元の地域
         day_to_ship_id: 発送までの日数
         price: 販売価格
+  activemodel:
+    attributes:
+      order_address:
+        post_code: 郵便番号
+        municipalities: 市区町村
+        address: 番地
+        telephone_num: 電話番号
+        prefectures_id: 都道府県
+        token: カード情報

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,3 +8,13 @@ ja:
         last_name: 名字
         last_name_kana: 名字(カナ)
         date_of_birth: 生年月日
+      item:
+        image: 商品画像
+        item_name: 商品名
+        item_text: 商品の説明
+        category_id: カテゴリー
+        sales_status_id: 商品の状態
+        shipping_cost_id: 配送料の負担
+        shipping_area_id: 配送元の地域
+        day_to_ship_id: 発送までの日数
+        price: 販売価格

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,47 +16,47 @@ RSpec.describe Item, type: :model do
       it 'item_nameが空だと登録できない' do
         @item.item_name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "商品名を入力してください"
+        expect(@item.errors.full_messages).to include '商品名を入力してください'
       end
       it 'item_textが空だと登録できない' do
         @item.item_text = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "商品の説明を入力してください"
+        expect(@item.errors.full_messages).to include '商品の説明を入力してください'
       end
       it 'category_idが1(---)だと登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "カテゴリーが選択されていません"
+        expect(@item.errors.full_messages).to include 'カテゴリーが選択されていません'
       end
       it 'sales_status_idが1(---)だと登録できない' do
         @item.sales_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "商品の状態が選択されていません"
+        expect(@item.errors.full_messages).to include '商品の状態が選択されていません'
       end
       it 'shipping_cost_idが1(---)だと登録できない' do
         @item.shipping_cost_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "配送料の負担が選択されていません"
+        expect(@item.errors.full_messages).to include '配送料の負担が選択されていません'
       end
       it 'shipping_area_idが1(---)だと登録できない' do
         @item.shipping_area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "配送元の地域が選択されていません"
+        expect(@item.errors.full_messages).to include '配送元の地域が選択されていません'
       end
       it 'day_to_ship_idが1(---)だと登録できない' do
         @item.day_to_ship_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "発送までの日数が選択されていません"
+        expect(@item.errors.full_messages).to include '発送までの日数が選択されていません'
       end
       it 'priceが空だと登録できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "販売価格を入力してください"
+        expect(@item.errors.full_messages).to include '販売価格を入力してください'
       end
       it 'imageが空だと登録できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "商品画像を入力してください"
+        expect(@item.errors.full_messages).to include '商品画像を入力してください'
       end
 
       it 'priceが全角英字では登録できない' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,99 +16,99 @@ RSpec.describe Item, type: :model do
       it 'item_nameが空だと登録できない' do
         @item.item_name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Item name can't be blank"
+        expect(@item.errors.full_messages).to include "商品名を入力してください"
       end
       it 'item_textが空だと登録できない' do
         @item.item_text = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Item text can't be blank"
+        expect(@item.errors.full_messages).to include "商品の説明を入力してください"
       end
       it 'category_idが1(---)だと登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Category can't be blank"
+        expect(@item.errors.full_messages).to include "カテゴリーが選択されていません"
       end
       it 'sales_status_idが1(---)だと登録できない' do
         @item.sales_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Sales status can't be blank"
+        expect(@item.errors.full_messages).to include "商品の状態が選択されていません"
       end
       it 'shipping_cost_idが1(---)だと登録できない' do
         @item.shipping_cost_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Shipping cost can't be blank"
+        expect(@item.errors.full_messages).to include "配送料の負担が選択されていません"
       end
       it 'shipping_area_idが1(---)だと登録できない' do
         @item.shipping_area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Shipping area can't be blank"
+        expect(@item.errors.full_messages).to include "配送元の地域が選択されていません"
       end
       it 'day_to_ship_idが1(---)だと登録できない' do
         @item.day_to_ship_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include "Day to ship can't be blank"
+        expect(@item.errors.full_messages).to include "発送までの日数が選択されていません"
       end
       it 'priceが空だと登録できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price can't be blank"
+        expect(@item.errors.full_messages).to include "販売価格を入力してください"
       end
       it 'imageが空だと登録できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "Image can't be blank"
+        expect(@item.errors.full_messages).to include "商品画像を入力してください"
       end
 
       it 'priceが全角英字では登録できない' do
         @item.price = 'ａａａＡＡＡ'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters'
+        expect(@item.errors.full_messages).to include '販売価格は半角数字で入力してください'
       end
       it 'priceが全角数字では登録できない' do
         @item.price = '１２３４５６７８９０'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters'
+        expect(@item.errors.full_messages).to include '販売価格は半角数字で入力してください'
       end
       it 'priceが全角漢字では登録できない' do
         @item.price = '一二三四五六七八九十'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters'
+        expect(@item.errors.full_messages).to include '販売価格は半角数字で入力してください'
       end
       it 'priceが全角ひらがなでは登録できない' do
         @item.price = 'いちにさんよんごろくななはちきゅう'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters'
+        expect(@item.errors.full_messages).to include '販売価格は半角数字で入力してください'
       end
       it 'priceが半角英字では登録できない' do
         @item.price = 'aaaAAA'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters'
+        expect(@item.errors.full_messages).to include '販売価格は半角数字で入力してください'
       end
       it 'priceが半角カタカナでは登録できない' do
         @item.price = 'ｲﾁﾆｻﾝｼｺﾞﾛｸﾅﾅﾊﾁｷｭｳ'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters'
+        expect(@item.errors.full_messages).to include '販売価格は半角数字で入力してください'
       end
       it 'priceが300円より小さい場合、登録できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price Out of setting range'
+        expect(@item.errors.full_messages).to include '販売価格は300以上の値にしてください'
       end
       it 'priceが9,999,999円より大きい場合、登録できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price Out of setting range'
+        expect(@item.errors.full_messages).to include '販売価格は9999999以下の値にしてください'
       end
       it 'priceがマイナスの場合、登録できない' do
         @item.price = '-1000'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price Out of setting range'
+        expect(@item.errors.full_messages).to include '販売価格は300以上の値にしてください'
       end
 
       it 'userと紐付いていないと登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include 'User must exist'
+        expect(@item.errors.full_messages).to include 'Userを入力してください'
       end
     end
   end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -23,92 +23,92 @@ RSpec.describe OrderAddress, type: :model do
       it 'post_codeが空だと登録できない' do
         @order_address.post_code = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Post code can't be blank"
+        expect(@order_address.errors.full_messages).to include "郵便番号を入力してください"
       end
       it 'prefectures_idが"---"(1)だと登録できない' do
         @order_address.prefectures_id = '1'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Prefectures can't be blank"
+        expect(@order_address.errors.full_messages).to include "都道府県が選択されていません"
       end
       it 'municipalitiesが空だと登録できない' do
         @order_address.municipalities = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Municipalities can't be blank"
+        expect(@order_address.errors.full_messages).to include "市区町村を入力してください"
       end
       it 'addressが空だと登録できない' do
         @order_address.address = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Address can't be blank"
+        expect(@order_address.errors.full_messages).to include "番地を入力してください"
       end
       it 'telephone_numが空だと登録できない' do
         @order_address.telephone_num = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Telephone num can't be blank"
+        expect(@order_address.errors.full_messages).to include "電話番号を入力してください"
       end
       it 'tokenが空だと登録できない' do
         @order_address.token = nil
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Token can't be blank"
+        expect(@order_address.errors.full_messages).to include "カード情報を入力してください"
       end
       it 'post_codeに"-"がないと登録できない' do
         @order_address.post_code = '1234567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Post code is invalid. Enter it as follows (e.g. 123-4567)'
+        expect(@order_address.errors.full_messages).to include '郵便番号を正しく入力してください(例 123-4567)'
       end
       it 'post_codeの3桁後に"-"ないと登録できない' do
         @order_address.post_code = '1234-567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Post code is invalid. Enter it as follows (e.g. 123-4567)'
+        expect(@order_address.errors.full_messages).to include '郵便番号を正しく入力してください(例 123-4567)'
       end
       it 'telephone_numが9桁以下だと登録できない' do
         @order_address.telephone_num = '123456789'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is too short'
+        expect(@order_address.errors.full_messages).to include '電話番号は10桁か11桁で入力してください'
       end
       it 'telephone_numが12桁以上だと登録できない' do
         @order_address.telephone_num = '123456789012'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is too short'
+        expect(@order_address.errors.full_messages).to include '電話番号は10桁か11桁で入力してください'
       end
       it 'telephone_numに半角英語が含まれている場合は登録できない' do
         @order_address.telephone_num = 'TellPhone'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください'
       end
       it 'telephone_numに半角カナが含まれている場合は登録できない' do
         @order_address.telephone_num = 'ﾃﾞﾝﾜﾊﾞﾝｺﾞｳ'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください'
       end
       it 'telephone_numに全角数字が含まれている場合は登録できない' do
         @order_address.telephone_num = '０９０１２３４５６７８'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください'
       end
       it 'telephone_numに全角カナが含まれている場合は登録できない' do
         @order_address.telephone_num = 'デンワバンゴウ'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください'
       end
       it 'telephone_numにひらがなが含まれている場合は登録できない' do
         @order_address.telephone_num = 'でんわばんごう'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください'
       end
       it 'telephone_numに漢字が含まれている場合は登録できない' do
         @order_address.telephone_num = '電話番号'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include 'Telephone num is invalid. Input only number'
+        expect(@order_address.errors.full_messages).to include '電話番号は半角数字のみで入力してください'
       end
       it 'user_idが空だと登録できない' do
         @order_address.user_id = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "User can't be blank"
+        expect(@order_address.errors.full_messages).to include "Userを入力してください"
       end
       it 'item_idが空だと登録できない' do
         @order_address.item_id = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Item can't be blank"
+        expect(@order_address.errors.full_messages).to include "Itemを入力してください"
       end
     end
   end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -23,32 +23,32 @@ RSpec.describe OrderAddress, type: :model do
       it 'post_codeが空だと登録できない' do
         @order_address.post_code = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "郵便番号を入力してください"
+        expect(@order_address.errors.full_messages).to include '郵便番号を入力してください'
       end
       it 'prefectures_idが"---"(1)だと登録できない' do
         @order_address.prefectures_id = '1'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "都道府県が選択されていません"
+        expect(@order_address.errors.full_messages).to include '都道府県が選択されていません'
       end
       it 'municipalitiesが空だと登録できない' do
         @order_address.municipalities = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "市区町村を入力してください"
+        expect(@order_address.errors.full_messages).to include '市区町村を入力してください'
       end
       it 'addressが空だと登録できない' do
         @order_address.address = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "番地を入力してください"
+        expect(@order_address.errors.full_messages).to include '番地を入力してください'
       end
       it 'telephone_numが空だと登録できない' do
         @order_address.telephone_num = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "電話番号を入力してください"
+        expect(@order_address.errors.full_messages).to include '電話番号を入力してください'
       end
       it 'tokenが空だと登録できない' do
         @order_address.token = nil
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "カード情報を入力してください"
+        expect(@order_address.errors.full_messages).to include 'カード情報を入力してください'
       end
       it 'post_codeに"-"がないと登録できない' do
         @order_address.post_code = '1234567'
@@ -103,12 +103,12 @@ RSpec.describe OrderAddress, type: :model do
       it 'user_idが空だと登録できない' do
         @order_address.user_id = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Userを入力してください"
+        expect(@order_address.errors.full_messages).to include 'Userを入力してください'
       end
       it 'item_idが空だと登録できない' do
         @order_address.item_id = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include "Itemを入力してください"
+        expect(@order_address.errors.full_messages).to include 'Itemを入力してください'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,69 +15,69 @@ RSpec.describe User, type: :model do
       it 'nicknameが空だと登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Nickname can't be blank"
+        expect(@user.errors.full_messages).to include "ニックネームを入力してください"
       end
 
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email can't be blank"
+        expect(@user.errors.full_messages).to include "メールアドレスを入力してください"
       end
 
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password can't be blank"
+        expect(@user.errors.full_messages).to include "パスワードを入力してください"
       end
 
       it '重複したemailが存在する場合は登録できない' do
         @user.save
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.valid?
-        expect(another_user.errors.full_messages).to include 'Email has already been taken'
+        expect(another_user.errors.full_messages).to include 'メールアドレスはすでに存在します'
       end
 
       it 'emailには＠が含まれていること' do
         @user.email = 'aaaaaaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Email is invalid'
+        expect(@user.errors.full_messages).to include 'メールアドレスは不正な値です'
       end
 
       it 'passwordは5文字以下では登録ができない' do
         @user.password = '00000'
         @user.password_confirmation = '00000'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
+        expect(@user.errors.full_messages).to include 'パスワードは6文字以上で入力してください'
       end
 
       it 'passwordは半角数字のみでは登録できない' do
         @user.password = '1234567890'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid'
+        expect(@user.errors.full_messages).to include 'パスワードは不正な値です'
       end
 
       it 'passwordは半角英字のみでは登録できない' do
         @user.password = 'aaaAAA'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid'
+        expect(@user.errors.full_messages).to include 'パスワードは不正な値です'
       end
 
       it 'passwordは全角英字では登録できない' do
         @user.password = 'ａａａＡＡＡ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid'
+        expect(@user.errors.full_messages).to include 'パスワードは不正な値です'
       end
 
       it 'passwordは全角数字では登録できない' do
         @user.password = '１２３４５６７８９０'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid'
+        expect(@user.errors.full_messages).to include 'パスワードは不正な値です'
       end
 
       it 'passwordとpassword_confirmationの値が一致していないと登録できない' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include "パスワード（確認用）とパスワードの入力が一致しません"
       end
     end
 
@@ -85,141 +85,141 @@ RSpec.describe User, type: :model do
       it 'last_nameが空では登録できない' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name can't be blank"
+        expect(@user.errors.full_messages).to include "名字を入力してください"
       end
       it 'last_name_kanaが空では登録できない' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana can't be blank"
+        expect(@user.errors.full_messages).to include "名字(カナ)を入力してください"
       end
       it 'first_nameが空では登録できない' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name can't be blank"
+        expect(@user.errors.full_messages).to include "名前を入力してください"
       end
       it 'first_name_kanaが空では登録できない' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name kana can't be blank"
+        expect(@user.errors.full_messages).to include "名前(カナ)を入力してください"
       end
       it 'date_of_birthが空では登録できない' do
         @user.date_of_birth = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Date of birth can't be blank"
+        expect(@user.errors.full_messages).to include "生年月日を入力してください"
       end
 
       it 'last_nameが全角英字では登録できない' do
         @user.last_name = 'Ｔａｎａｋａ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name is invalid'
+        expect(@user.errors.full_messages).to include '名字は不正な値です'
       end
       it 'last_nameが全角数字では登録できない' do
         @user.last_name = '１２３４５６７８９０'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name is invalid'
+        expect(@user.errors.full_messages).to include '名字は不正な値です'
       end
       it 'last_nameが半角英字では登録できない' do
         @user.last_name = 'Tanaka'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name is invalid'
+        expect(@user.errors.full_messages).to include '名字は不正な値です'
       end
       it 'last_nameが半角数字では登録できない' do
         @user.last_name = '123456790'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name is invalid'
+        expect(@user.errors.full_messages).to include '名字は不正な値です'
       end
 
       it 'last_name_kanaが全角英字では登録できない' do
         @user.last_name_kana = 'Ｔａｎａｋａ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana is invalid'
+        expect(@user.errors.full_messages).to include '名字(カナ)は不正な値です'
       end
       it 'last_name_kanaが全角数字では登録できない' do
         @user.last_name_kana = '１２３４５６７８９０'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana is invalid'
+        expect(@user.errors.full_messages).to include '名字(カナ)は不正な値です'
       end
       it 'last_name_kanaが全角漢字では登録できない' do
         @user.last_name_kana = '田中'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana is invalid'
+        expect(@user.errors.full_messages).to include '名字(カナ)は不正な値です'
       end
       it 'last_name_kanaが全角ひらがなでは登録できない' do
         @user.last_name_kana = 'たなか'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana is invalid'
+        expect(@user.errors.full_messages).to include '名字(カナ)は不正な値です'
       end
       it 'last_name_kanaが半角英字では登録できない' do
         @user.last_name_kana = 'Tanaka'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana is invalid'
+        expect(@user.errors.full_messages).to include '名字(カナ)は不正な値です'
       end
       it 'last_name_kanaが半角数字では登録できない' do
         @user.last_name_kana = '1234567890'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana is invalid'
+        expect(@user.errors.full_messages).to include '名字(カナ)は不正な値です'
       end
       it 'last_name_kanaが半角カタカナでは登録できない' do
         @user.last_name_kana = 'ﾀﾅｶ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana is invalid'
+        expect(@user.errors.full_messages).to include '名字(カナ)は不正な値です'
       end
 
       it 'first_nameが全角英字では登録できない' do
         @user.first_name = 'Ｔａｒｏ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name is invalid'
+        expect(@user.errors.full_messages).to include '名前は不正な値です'
       end
       it 'first_nameが全角数字では登録できない' do
         @user.first_name = '１２３４５６７８９０'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name is invalid'
+        expect(@user.errors.full_messages).to include '名前は不正な値です'
       end
       it 'first_nameが半角英字では登録できない' do
         @user.first_name = 'Taro'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name is invalid'
+        expect(@user.errors.full_messages).to include '名前は不正な値です'
       end
       it 'first_nameが半角数字では登録できない' do
         @user.first_name = '1234567890'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name is invalid'
+        expect(@user.errors.full_messages).to include '名前は不正な値です'
       end
 
       it 'first_name_kanaが全角英字では登録できない' do
         @user.first_name_kana = 'Ｔａｒｏ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana is invalid'
+        expect(@user.errors.full_messages).to include '名前(カナ)は不正な値です'
       end
       it 'first_name_kanaが全角数字では登録できない' do
         @user.first_name_kana = '１２３４５６７８９０'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana is invalid'
+        expect(@user.errors.full_messages).to include '名前(カナ)は不正な値です'
       end
       it 'first_name_kanaが全角漢字では登録できない' do
         @user.first_name_kana = '太郎'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana is invalid'
+        expect(@user.errors.full_messages).to include '名前(カナ)は不正な値です'
       end
       it 'first_name_kanaが全角ひらがなでは登録できない' do
         @user.first_name_kana = 'たろう'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana is invalid'
+        expect(@user.errors.full_messages).to include '名前(カナ)は不正な値です'
       end
       it 'first_name_kanaが半角英字では登録できない' do
         @user.first_name_kana = 'Taro'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana is invalid'
+        expect(@user.errors.full_messages).to include '名前(カナ)は不正な値です'
       end
       it 'first_name_kanaが半角数字では登録できない' do
         @user.first_name_kana = '1234567890'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana is invalid'
+        expect(@user.errors.full_messages).to include '名前(カナ)は不正な値です'
       end
       it 'first_name_kanaが半角カタカナでは登録できない' do
         @user.first_name_kana = 'ﾀﾛｳ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana is invalid'
+        expect(@user.errors.full_messages).to include '名前(カナ)は不正な値です'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe User, type: :model do
       it 'nicknameが空だと登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "ニックネームを入力してください"
+        expect(@user.errors.full_messages).to include 'ニックネームを入力してください'
       end
 
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "メールアドレスを入力してください"
+        expect(@user.errors.full_messages).to include 'メールアドレスを入力してください'
       end
 
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "パスワードを入力してください"
+        expect(@user.errors.full_messages).to include 'パスワードを入力してください'
       end
 
       it '重複したemailが存在する場合は登録できない' do
@@ -77,7 +77,7 @@ RSpec.describe User, type: :model do
       it 'passwordとpassword_confirmationの値が一致していないと登録できない' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "パスワード（確認用）とパスワードの入力が一致しません"
+        expect(@user.errors.full_messages).to include 'パスワード（確認用）とパスワードの入力が一致しません'
       end
     end
 
@@ -85,27 +85,27 @@ RSpec.describe User, type: :model do
       it 'last_nameが空では登録できない' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "名字を入力してください"
+        expect(@user.errors.full_messages).to include '名字を入力してください'
       end
       it 'last_name_kanaが空では登録できない' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "名字(カナ)を入力してください"
+        expect(@user.errors.full_messages).to include '名字(カナ)を入力してください'
       end
       it 'first_nameが空では登録できない' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "名前を入力してください"
+        expect(@user.errors.full_messages).to include '名前を入力してください'
       end
       it 'first_name_kanaが空では登録できない' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "名前(カナ)を入力してください"
+        expect(@user.errors.full_messages).to include '名前(カナ)を入力してください'
       end
       it 'date_of_birthが空では登録できない' do
         @user.date_of_birth = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "生年月日を入力してください"
+        expect(@user.errors.full_messages).to include '生年月日を入力してください'
       end
 
       it 'last_nameが全角英字では登録できない' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-I18n.locale = 'en'
+# I18n.locale = 'en'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
# What
エラーメッセージを日本語で表示させる

# Why
日本人ユーザーが入力に誤りがあったときにどこでどのようなミスがあるのか分かりやすくする為

【新規登録時のエラー表示】
https://gyazo.com/adbb38d3a62833d9ea70c15bbea178fd

【ログイン時のエラー表示】
https://gyazo.com/942db7916205ce8ec24dbfb271de7856

【出品時のエラー表示】
https://gyazo.com/41cb13b085e5c9731bc1ab69c74aca32

【購入時のエラー表示】
https://gyazo.com/574622ed2633964379aae45d5c46fc74

【userモデルの単体テストの結果】
https://gyazo.com/1e1841b54a1c884dbece8bfb52d05029

【itemモデルの単体テストの結果】
https://gyazo.com/6ee8f37d73591089d5df601016d11153

【order_addressモデルの単体テストの結果】
https://gyazo.com/d0df577aa5b0557cf29d92891334b928